### PR TITLE
Moved explorer.next() in compute before outputImages and category are recorded.

### DIFF
--- a/nupicvision/regions/ImageSensor.py
+++ b/nupicvision/regions/ImageSensor.py
@@ -2000,6 +2000,13 @@ class ImageSensor(PyRegion):
     if newSequenceID != prevSequenceID:
       self.prevPosition['reset'] = True
 
+    holdFor = self.explorer[2].holdFor
+    self._holdForOffset += 1
+    if self._holdForOffset >= holdFor:
+      self._holdForOffset = 0
+      self.explorer[2].next()
+    self._iteration += 1
+
     # Get the image(s) to send out
     outputImages, final_output = self._getOutputImages()
 
@@ -2046,13 +2053,6 @@ class ImageSensor(PyRegion):
       self._logOriginalImage()
     if self.logLocationImages:
       self._logLocationImage()
-
-    holdFor = self.explorer[2].holdFor
-    self._holdForOffset += 1
-    if self._holdForOffset >= holdFor:
-      self._holdForOffset = 0
-      self.explorer[2].next()
-    self._iteration += 1
 
     # Save category to file
     self._writeCategoryToFile(category)


### PR DESCRIPTION
### Changes (fixes) functionality of ImageSensor

This moves the block of code that runs `self.explorer[2].next()` in the compute method of ImageSensor. It is moved before the `category` is recorded ([here](https://github.com/numenta/nupic.vision/pull/27/files#diff-dd1da592014fff7e9bdf8f103adeed6aR2019)) so that the current image sensor output matches the category. Otherwise the category output of an image will actually lag behind by a step of what the category actually is. This way the `category` matches with what the `outputs` are (outputs were set after the original code's `explorer.next` was called).

@subutai Please review this when you get a chance