### PR TITLE
Fix dependencies of ImageSensor Region

### DIFF
--- a/nupic/vision/regions/ImageSensor.py
+++ b/nupic/vision/regions/ImageSensor.py
@@ -39,10 +39,10 @@ from PIL import (Image,
                  ImageDraw)
 
 from nupic.bindings.math import GetNTAReal
-from nupic.image import (serializeImage,
+from nupic.vision.image import (serializeImage,
                          deserializeImage,
                          imageExtensions)
-from nupic.regions.PyRegion import PyRegion
+from nupic.bindings.regions.PyRegion import PyRegion
 
 
 


### PR DESCRIPTION
@scottpurdy 

I fixed the dependencies of the ImageSensor (I think). But I still have trouble register and add ImageSensor Region to the network.

First, ImageSensor Region somehow is still on the list of default nupic regions. https://github.com/numenta/nupic/blob/master/src/nupic/engine/__init__.py#L51
So register it again will cause an error. 

If I unregister ImageSensor Region first, I got another error of `RuntimeError: Matching Python module for ImageSensor not found.` I am not sure why this occurs.